### PR TITLE
Fix order of RF adaptor columns.

### DIFF
--- a/modules/Bio/EnsEMBL/Funcgen/DBSQL/RegulatoryFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Funcgen/DBSQL/RegulatoryFeatureAdaptor.pm
@@ -394,10 +394,10 @@ sub _objs_from_sth {
      \$stable_id,         
      \$bin_string,
      \$projected,         
-     \$attr_id,
-     \$attr_type,
      \$has_evidence,
      \$cell_type_count,
+     \$attr_id,
+     \$attr_type,
     );
 
 	my ($asm_cs, $cmp_cs, $asm_cs_name);


### PR DESCRIPTION
There seems to be a problem with the order of the new attr and evidence/cell-type columns being switched between columns() and the corresponding bind in _objs_from_sth. This patch flips the latter to match the former.
