### PR TITLE
syntax bugfix: keys is for hash references

### DIFF
--- a/modules/Bio/EnsEMBL/Funcgen/Sequencing/MotifTools.pm
+++ b/modules/Bio/EnsEMBL/Funcgen/Sequencing/MotifTools.pm
@@ -238,7 +238,7 @@ sub write_matrix_file{
   my $out_path      = shift;
   my $write_header  = shift;
   assert_ref($matrix_hashes, 'ARRAY', '$matrix_hashes');
-  $write_header     = 1 if scalar(keys @$matrix_hashes) > 1;
+  $write_header     = 1 if scalar(@$matrix_hashes) > 1;
   my $out_file      = open_file($out_path, '>');
 
   foreach my $mhash(@$matrix_hashes){


### PR DESCRIPTION
`perl -c` doesn't complain, it's only at runtime (whilst running the ensembl-rest test-suite) that I got the error:
```
/home/travis/build/Ensembl/ensembl-compara/ensembl-rest/t/taxonomy.t ........... Type of arg 1 to keys must be hash (not array dereference) at /home/travis/build/Ensembl/ensembl-compara/ensembl-funcgen/modules/Bio/EnsEMBL/Funcgen/Sequencing/MotifTools.pm line 241, near "$matrix_hashes) "
Compilation failed in require at /home/travis/build/Ensembl/ensembl-compara/ensembl-funcgen/modules/Bio/EnsEMBL/Funcgen/BindingMatrix.pm line 76.
BEGIN failed--compilation aborted at /home/travis/build/Ensembl/ensembl-compara/ensembl-funcgen/modules/Bio/EnsEMBL/Funcgen/BindingMatrix.pm line 76.
Compilation failed in require at /home/travis/build/Ensembl/ensembl-compara/ensembl-variation/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm line 85.
BEGIN failed--compilation aborted at /home/travis/build/Ensembl/ensembl-compara/ensembl-variation/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm line 85.
Compilation failed in require at /home/travis/build/Ensembl/ensembl-compara/ensembl-variation/modules/Bio/EnsEMBL/Variation/VCFCollection.pm line 74.
BEGIN failed--compilation aborted at /home/travis/build/Ensembl/ensembl-compara/ensembl-variation/modules/Bio/EnsEMBL/Variation/VCFCollection.pm line 74.
Compilation failed in require at /home/travis/build/Ensembl/ensembl-compara/ensembl-variation/modules/Bio/EnsEMBL/Variation/DBSQL/VCFCollectionAdaptor.pm line 95.
BEGIN failed--compilation aborted at /home/travis/build/Ensembl/ensembl-compara/ensembl-variation/modules/Bio/EnsEMBL/Variation/DBSQL/VCFCollectionAdaptor.pm line 95.
Compilation failed in require at /home/travis/build/Ensembl/ensembl-compara/ensembl-rest/lib/EnsEMBL/REST/Model/ga4gh/callSet.pm line 24.
BEGIN failed--compilation aborted at /home/travis/build/Ensembl/ensembl-compara/ensembl-rest/lib/EnsEMBL/REST/Model/ga4gh/callSet.pm line 24.
Compilation failed in require at /home/travis/perl5/perlbrew/perls/5.10/lib/site_perl/5.10.1/Catalyst/Utils.pm line 309.
Compilation failed in require at /home/travis/perl5/perlbrew/perls/5.10/lib/site_perl/5.10.1/Catalyst/Test.pm line 155.
```