### PR TITLE
Return empty arrayref if this epigenome has no activity

### DIFF
--- a/modules/Bio/EnsEMBL/Funcgen/RegulatoryFeature.pm
+++ b/modules/Bio/EnsEMBL/Funcgen/RegulatoryFeature.pm
@@ -213,6 +213,7 @@ sub regulatory_evidence {
   
   $self->_assert_epigenome_ok($epigenome);
   my $regulatory_activity = $self->regulatory_activity_for_epigenome($epigenome);
+  return [] unless $regulatory_activity;
   
   my $regulatory_evidence = $regulatory_activity->regulatory_evidence;
     


### PR DESCRIPTION
This method breaks the zmenu of a regulatory feature in an inactive epigenome. See JIRA: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-2865