### PR TITLE
Check probe_seq_id is defined before fetching the sequence

### DIFF
--- a/modules/Bio/EnsEMBL/Funcgen/Probe.pm
+++ b/modules/Bio/EnsEMBL/Funcgen/Probe.pm
@@ -197,7 +197,9 @@ sub sequence {
     my $self = shift;
     $self->{'sequence'} = shift if @_;
 
-    if (! defined $self->{'sequence'}) {
+    if (! defined $self->{'sequence'}
+        && (defined $self->_probe_seq_id)
+    ) {
       $self->{'sequence'} = $self->get_ProbeSequence->sequence;
     }
 


### PR DESCRIPTION
This is to fix a bug where if the probe_seq_id is NULL it results in error.

Please could you also cherry-pick this change to master if that is OK.