### PR TITLE
SequenceOntologyMapper deprecation update

### DIFF
--- a/modules/Bio/EnsEMBL/Funcgen/RegulatoryFeature.pm
+++ b/modules/Bio/EnsEMBL/Funcgen/RegulatoryFeature.pm
@@ -74,6 +74,8 @@ use Bio::EnsEMBL::Utils::Exception qw( throw deprecate );
 
 use base qw( Bio::EnsEMBL::Feature Bio::EnsEMBL::Funcgen::Storable );
 
+use constant SO_ACC => 'SO:0005836';
+
 =head2 new
 
   Arg [-SLICE]             : Bio::EnsEMBL::Slice - The slice on which this feature is located.


### PR DESCRIPTION
`Bio::EnsEMBL::Utils::SequenceOntologyMapper` is being deprecated with https://github.com/Ensembl/ensembl/pull/246
That functionality is being replaced with Bio::EnsEMBL::Feature::feature_so_acc, and all features will be able to use that method provided they declare a constant SO_ACC.
I'm making sure all the 'features' that were supported on SequenceOntologyMapper are compliant so that pipelines that use it can be updated seamlessly.
RegulatoryFeature is one of the features that require SO_ACC.