### PR TITLE
Standardise table.sql file

### DIFF
--- a/sql/table.sql
+++ b/sql/table.sql
@@ -519,9 +519,7 @@ CREATE TABLE `motif_feature` (
   `stable_id` VARCHAR(18) DEFAULT NULL,
   PRIMARY KEY (`motif_feature_id`),
   UNIQUE KEY `stable_id_idx` (`stable_id`),
-  UNIQUE KEY `unique_idx` (
-    `binding_matrix_id`, `seq_region_id`, `seq_region_start`,
-     `seq_region_strand`),
+  UNIQUE KEY `unique_idx` (`binding_matrix_id`, `seq_region_id`, `seq_region_start`, `seq_region_strand`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `binding_matrix_idx` (`binding_matrix_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=latin1;


### PR DESCRIPTION
The new datacheck for validating a db schema uses the table.sql file.
This is mostly consistent already, both within the file and between instances of the files in different repositories. But there are a few simple changes to terminology and formatting that would further standardise the files. These sorts of things can be handled in the datacheck code, but having fewer, and less complicated, exceptions makes the code more robust and easier to understand.
