### PR TITLE
add new activities labels patch

### DIFF
--- a/sql/patch_110_111_a.sql
+++ b/sql/patch_110_111_a.sql
@@ -1,0 +1,27 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2023] EMBL-European Bioinformatics Institute
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+/**
+@header patch_110_111_a.sql - Add new activities labels
+@desc   Add EVIDENCE/NO EVIDENCE labels to regulatory_activity table
+*/
+
+ALTER TABLE regulatory_activity 
+MODIFY COLUMN activity enum('INACTIVE','REPRESSED','POISED','ACTIVE','EVIDENCE','NO EVIDENCE','NA') 
+CHARACTER SET latin1 
+COLLATE latin1_swedish_ci 
+NOT NULL;
+
+-- patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_110_111_a.sql|Add new activities labels');


### PR DESCRIPTION
## Description
Implementation of the patch that adds `EVIDENCE`/`NO EVIDENCE` as possible activity statuses in `activity` table.
## Sandbox
- Activity track: http://wp-np2-25.ebi.ac.uk:6030/Dicentrarchus_labrax/Location/View?db=core;fdb=funcgen;r=CAJNNU010000005.1:20646964-20670058;rf=ENSDLAR00000026639
- Regulation view: http://wp-np2-25.ebi.ac.uk:6030/Dicentrarchus_labrax/Regulation/Summary?db=core;fdb=funcgen;r=CAJNNU010000005.1:20646964-20670058;rf=ENSDLAR00000026639
## Jira ticket
[ENSREGULATION-1769](https://www.ebi.ac.uk/panda/jira/browse/ENSREGULATION-1769)