### PR TITLE
[main] Fix data_file_id length

### DIFF
--- a/sql/patch_110_111_b.sql
+++ b/sql/patch_110_111_b.sql
@@ -1,0 +1,24 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2023] EMBL-European Bioinformatics Institute
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--      http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+/**
+@header patch_110_111_b.sql - fix data_file_id length
+@desc   Update data_file_id in data_file and epigenome_track tables to int(10) unsigned
+*/
+
+ALTER TABLE data_file MODIFY data_file_id int(10) unsigned;
+ALTER TABLE epigenome_track MODIFY data_file_id int(10) unsigned;
+
+-- patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_110_111_b.sql|fix data_file_id length');

--- a/sql/patch_111_112_a.sql
+++ b/sql/patch_111_112_a.sql
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 /**
-@header patch_110_111_b.sql - fix data_file_id length
+@header patch_111_112_a.sql - fix data_file_id length
 @desc   Update data_file_id in data_file and epigenome_track tables to int(10) unsigned
 */
 
@@ -21,4 +21,4 @@ ALTER TABLE data_file MODIFY data_file_id int(10) unsigned;
 ALTER TABLE epigenome_track MODIFY data_file_id int(10) unsigned;
 
 -- patch identifier
-INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_110_111_b.sql|fix data_file_id length');
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_111_112_a.sql|fix data_file_id length');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1520,7 +1520,7 @@ CREATE TABLE `epigenome_track` (
   `epigenome_track_id` INT(10) unsigned NOT NULL AUTO_INCREMENT,
   `epigenome_id` INT(10) unsigned NOT NULL,
   `feature_type_id` INT(10) unsigned NOT NULL,
-  `data_file_id` INT(11) unsigned NOT NULL,
+  `data_file_id` INT(10) unsigned NOT NULL,
   `track_type` VARCHAR(50),
   INDEX et_index ( epigenome_id, feature_type_id ),
   PRIMARY KEY (epigenome_track_id)

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1148,7 +1148,7 @@ CREATE TABLE `alignment_qc_flagstats` (
 
 DROP TABLE IF EXISTS `data_file`;
 CREATE TABLE `data_file` (
-  `data_file_id` int(11) NOT NULL AUTO_INCREMENT,
+  `data_file_id` int(10) NOT NULL AUTO_INCREMENT,
   `table_id` int(10) unsigned NOT NULL,
   `table_name` varchar(32) NOT NULL,
   `path` varchar(255) NOT NULL,


### PR DESCRIPTION
Fix based on the bug reported [here](https://genomes-ebi.slack.com/archives/C0HTN4Y9L/p1685550927351589).

Alter the precision and length of the `pk` from `data_file` table:
- `int(11)` -> `int(10)`