### PR TITLE
113 fix MyISAM issue

### DIFF
--- a/sql/patch_112_113_b.sql
+++ b/sql/patch_112_113_b.sql
@@ -17,6 +17,7 @@
 @desc   Fix compatibility issues
 */
 
+ALTER TABLE meta MODIFY meta_value varchar(255) DEFAULT NULL;
 ALTER TABLE meta MODIFY meta_key varchar(64) NOT NULL;
 ALTER TABLE data_file MODIFY data_file_id int(10) NOT NULL AUTO_INCREMENT;
 ALTER TABLE epigenome_track MODIFY data_file_id int(10) unsigned NOT NULL;

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1674,7 +1674,7 @@ CREATE TABLE `meta` (
   `meta_id` int(10) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
   `meta_key` varchar(64) NOT NULL,
-  `meta_value` varchar(950) NOT NULL,
+  `meta_value` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)


### PR DESCRIPTION
The error (Specified key was too long; max key length is 1000 bytes) occurs when the Patch tries to increase the meta_key column to varchar(64).
Searching for a solution, I found out that it's related to the MySQL engine (MyISAM).
The engine computes the max key length based on the current columns.